### PR TITLE
refactor(tabs): remove block style

### DIFF
--- a/packages/ngx-foundation-sites/src/lib/tabs/tab.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/tabs/tab.component.ts
@@ -16,13 +16,6 @@ let serialNumber = 1;
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   selector: 'fas-tab',
-  styles: [
-    `
-      fas-tab {
-        display: block;
-      }
-    `,
-  ],
   template: `<ng-content></ng-content>`,
 })
 export class FasTabComponent {


### PR DESCRIPTION
# Tabs
- Remove unnecessary block style. Foundation for Sites Tabs have `display: none;` by default.