### PR TITLE
refactor: use lightweight `FasTabToken` to support tree-shaking of `FasTabComponent`

### DIFF
--- a/packages/ngx-foundation-sites/src/lib/tabs/tab.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/tabs/tab.component.ts
@@ -11,6 +11,12 @@ import {
 
 let serialNumber = 1;
 
+export abstract class FasTabToken {
+  abstract active: boolean;
+  abstract get id(): string;
+  abstract title: string;
+}
+
 @Component({
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -18,8 +24,14 @@ let serialNumber = 1;
   selector: 'fas-tab',
   imports: [],
   template: `<ng-content></ng-content>`,
+  providers: [
+    {
+      provide: FasTabToken,
+      useExisting: FasTabComponent,
+    },
+  ],
 })
-export class FasTabComponent {
+export class FasTabComponent implements FasTabToken {
   #id = '';
   #isActive = false;
 

--- a/packages/ngx-foundation-sites/src/lib/tabs/tabs.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/tabs/tabs.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
-import { FasTabComponent } from './tab.component';
+import { FasTabToken } from './tab.component';
 
 @Component({
   standalone: true,
@@ -50,10 +50,10 @@ export class FasTabsComponent {
   @Input()
   vertical = false;
 
-  @ContentChildren(FasTabComponent)
-  tabs!: QueryList<FasTabComponent>;
+  @ContentChildren(FasTabToken)
+  tabs!: QueryList<FasTabToken>;
 
-  selectTab(selectedTab: FasTabComponent): void {
+  selectTab(selectedTab: FasTabToken): void {
     const activeTab = this.tabs.find(t => t.active);
 
     if (this.collapsing && activeTab === selectedTab) {


### PR DESCRIPTION
Closes #62.