### PR TITLE
feat: use string properties for attribute bindings

### DIFF
--- a/packages/ngx-foundation-sites/src/lib/progress-bar/meter/meter.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/meter/meter.component.ts
@@ -20,21 +20,40 @@ import {
 })
 export class FasMeterComponent {
   @Input()
-  @HostBinding('attr.high')
   high: number | null = null;
   @Input()
-  @HostBinding('attr.low')
   low: number | null = null;
   @Input()
-  @HostBinding('attr.max')
   max: number | null = null;
   @Input()
-  @HostBinding('attr.min')
   min: number | null = null;
   @Input()
-  @HostBinding('attr.optimum')
   optimum: number | null = null;
   @Input()
-  @HostBinding('attr.value')
   value: number | null = null;
+
+  @HostBinding('attr.high')
+  get highAttribute(): string | null {
+    return this.high === null ? null : String(this.high);
+  }
+  @HostBinding('attr.low')
+  get lowAttribute(): string | null {
+    return this.low === null ? null : String(this.low);
+  }
+  @HostBinding('attr.max')
+  get maxAttribute(): string | null {
+    return this.max === null ? null : String(this.max);
+  }
+  @HostBinding('attr.min')
+  get minAttribute(): string | null {
+    return this.min === null ? null : String(this.min);
+  }
+  @HostBinding('attr.optimum')
+  get optimumAttribute(): string | null {
+    return this.optimum === null ? null : String(this.optimum);
+  }
+  @HostBinding('attr.value')
+  get valueAttribute(): string | null {
+    return this.value === null ? null : String(this.value);
+  }
 }

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress/progress.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress/progress.component.ts
@@ -36,7 +36,6 @@ export class FasProgressComponent {
     this.#color = color ?? defaultColor;
   }
   @Input()
-  @HostBinding('attr.max')
   set max(max: number | null) {
     max ??= this.#maxDefault;
 
@@ -50,7 +49,6 @@ export class FasProgressComponent {
     return this.#max;
   }
   @Input()
-  @HostBinding('attr.value')
   set value(value: number | null) {
     if (value !== null && value <= 0) {
       return;
@@ -64,5 +62,14 @@ export class FasProgressComponent {
   }
   get value(): number | null {
     return this.#value;
+  }
+
+  @HostBinding('attr.max')
+  get maxAttribute(): string {
+    return String(this.#max);
+  }
+  @HostBinding('attr.value')
+  get valueAttribute(): string | null {
+    return this.#value === null ? null : String(this.#value);
   }
 }


### PR DESCRIPTION
Prevent coercien and remove attributes from the DOM when `null` is bound.

Closes #70.