### PR TITLE
refactor: migrate Storybook example app stylesheet to Sass modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "jest-preset-angular": "13.0.1",
     "lodash-es": "4.17.21",
     "marked": "4.3.0",
+    "motion-ui": "2.0.4",
     "ng-packagr": "15.2.2",
     "nx": "15.8.9",
     "postcss": "8.4.12",

--- a/packages/ngx-foundation-sites/src/lib/_global-foundation-sites-settings.scss
+++ b/packages/ngx-foundation-sites/src/lib/_global-foundation-sites-settings.scss
@@ -1,0 +1,16 @@
+// Foundation for Sites default global settings
+// Must be imported by every component stylesheet
+$global-text-direction: ltr;
+$global-left: if($global-text-direction == rtl, right, left);
+$global-flexbox: true;
+$global-radius: var(--fas-progress-radius);
+
+$white: var(--fas-white);
+$primary-color: var(--fas-primary-color);
+$foundation-palette: (
+  primary: var(--fas-primary-color),
+  secondary: var(--fas-secondary-color),
+  success: var(--fas-success-color),
+  warning: var(--fas-warning-color),
+  alert: var(--fas-alert-color),
+);

--- a/packages/ngx-foundation-sites/src/lib/card/card.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/card/card.component.scss
@@ -1,5 +1,6 @@
+@import '../global-foundation-sites-settings';
+
 // Foundation for Sites global tools
-@import 'foundation-sites/scss/global';
 
 // Foundation for Sites Card settings
 $card-background: var(--fas-card-background);

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/meter/meter.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/meter/meter.component.scss
@@ -1,5 +1,6 @@
+@import '../../global-foundation-sites-settings';
+
 // Foundation for Sites global tools
-@import 'foundation-sites/scss/global';
 
 // Foundation for Sites Meter settings
 $meter-height: var(--fas-meter-height);

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/meter/native-meter.stories.ts
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/meter/native-meter.stories.ts
@@ -20,12 +20,7 @@ difference?
 
 The meter automatically colors itself based on the current values, and the
 defined low, medium, and high ranges.
-<a
-  href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter"
-  target="_blank"
-  rel="noopener"
-  >Learn more about the mechanics of \`<meter>\` values</a
->.`,
+[Learn more about the mechanics of \`<meter>\` values](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter).`,
       },
     },
   },

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-bar.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-bar.component.scss
@@ -1,5 +1,7 @@
+@import '../../global-foundation-sites-settings';
+
 // Foundation for Sites global tools
-@import 'foundation-sites/scss/global';
+@import 'foundation-sites/scss/util/mixins';
 
 // Foundation for Sites Progress Bar settings
 $progress-height: var(--fas-progress-height);
@@ -12,57 +14,6 @@ $progress-radius: var(--fas-progress-radius);
 @import 'foundation-sites/scss/components/progress-bar';
 
 // Foundation for Sites Progress Bar tools overrides
-
-//
-// 1. Replace for loop generating themes from the palette with static classes
-//    referring to CSS Custom Properties.
-//
-@mixin foundation-progress-bar {
-  // Progress bar
-  .progress {
-    @include progress-container;
-
-    &.primary /* [1] */ {
-      .progress-meter {
-        background-color: var(--fas-primary-color);
-      }
-    }
-
-    &.secondary /* [1] */ {
-      .progress-meter {
-        background-color: var(--fas-secondary-color);
-      }
-    }
-
-    &.success /* [1] */ {
-      .progress-meter {
-        background-color: var(--fas-success-color);
-      }
-    }
-
-    &.warning /* [1] */ {
-      .progress-meter {
-        background-color: var(--fas-warning-color);
-      }
-    }
-
-    &.alert /* [1] */ {
-      .progress-meter {
-        background-color: var(--fas-alert-color);
-      }
-    }
-  }
-
-  // Inner meter
-  .progress-meter {
-    @include progress-meter;
-  }
-
-  // Inner meter text
-  .progress-meter-text {
-    @include progress-meter-text;
-  }
-}
 
 fas-progress-bar {
   // Foundation for Angular Sites Progress Bar settings

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress/progress.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress/progress.component.scss
@@ -1,5 +1,6 @@
+@import '../../global-foundation-sites-settings';
+
 // Foundation for Sites global tools
-@import 'foundation-sites/scss/global';
 
 // Foundation for Sites Progress settings
 $progress-height: var(--fas-progress-height);
@@ -12,93 +13,6 @@ $progress-radius: var(--fas-progress-radius);
 @import 'foundation-sites/scss/forms/progress';
 
 // Foundation for Sites Progress tools overrides
-
-@mixin _fas-progress-color($color) {
-  &::-webkit-progress-value {
-    background: $color;
-  }
-
-  &::-moz-progress-bar {
-    background: $color;
-  }
-}
-
-//
-// 1. Replace for loop generating themes from the palette with static classes
-//    referring to CSS Custom Properties.
-//
-@mixin foundation-progress-element {
-  progress {
-    display: block;
-    width: 100%;
-    height: $progress-height;
-    margin-bottom: $progress-margin-bottom;
-
-    appearance: none;
-
-    @if has-value($progress-radius) {
-      border-radius: $progress-radius;
-    }
-
-    // For Firefox
-    border: 0;
-    background: $progress-background;
-
-    &::-webkit-progress-bar {
-      background: $progress-background;
-
-      @if has-value($progress-radius) {
-        border-radius: $progress-radius;
-      }
-    }
-
-    &::-webkit-progress-value {
-      background: $progress-meter-background;
-
-      @if has-value($progress-radius) {
-        border-radius: $progress-radius;
-      }
-    }
-
-    &::-moz-progress-bar {
-      background: $progress-meter-background;
-
-      @if has-value($progress-radius) {
-        border-radius: $progress-radius;
-      }
-    }
-
-    &.primary /* [1] */ {
-      @include _fas-progress-color(var(--fas-primary-color));
-    }
-
-    &.secondary /* [1] */ {
-      @include _fas-progress-color(var(--fas-secondary-color));
-    }
-
-    &.success /* [1] */ {
-      @include _fas-progress-color(var(--fas-success-color));
-    }
-
-    &.warning /* [1] */ {
-      @include _fas-progress-color(var(--fas-warning-color));
-    }
-
-    &.alert /* [1] */ {
-      @include _fas-progress-color(var(--fas-alert-color));
-    }
-
-    // For IE and Edge
-    &::-ms-fill {
-      // sass-lint:disable-line no-vendor-prefixes
-      @if has-value($progress-radius) {
-        border-radius: $progress-radius;
-      }
-
-      border: 0;
-    }
-  }
-}
 
 [fas-progress] {
   // Foundation for Angular Sites Progress settings

--- a/packages/ngx-foundation-sites/src/lib/tabs/tabs.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/tabs/tabs.component.scss
@@ -1,5 +1,7 @@
+@import '../global-foundation-sites-settings';
+
 // Foundation for Sites global tools
-@import 'foundation-sites/scss/global';
+@import 'foundation-sites/scss/util/mixins';
 
 // Foundation for Sites Tabs settings
 $tab-margin: var(--fas-tab-margin);
@@ -28,8 +30,7 @@ $tab-content-padding: var(--fas-tab-content-padding);
   $padding: $tab-item-padding,
   $font-size: $tab-item-font-size,
   $color: $tab-color,
-  // [1]
-  $color-hover: $tab-color-hover,
+  $color-hover: $tab-color-hover /* [1] */,
   $color-active: $tab-active-color,
   $background-hover: $tab-item-background-hover,
   $background-active: $tab-background-active

--- a/packages/ngx-foundation-sites/src/storybook/styles.scss
+++ b/packages/ngx-foundation-sites/src/storybook/styles.scss
@@ -1,18 +1,18 @@
-@import 'styles/foundation-sites';
+@use 'styles/foundation-sites' as app;
 
-@include foundation-example-app;
+@include app.foundation-example-app;
 
 // Foundation for Angular Sites global styles overrides
 :root:root /* Increase specificity to override component styles */ {
-  --fas-primary-color: #{map-get($foundation-palette, primary)};
+  --fas-primary-color: #{map-get(app.$foundation-palette, primary)};
   --fas-primary-color-dark: #{scale-color(
-      map-get($foundation-palette, primary),
+      map-get(app.$foundation-palette, primary),
       $lightness: -14%
     )};
-  --fas-secondary-color: #{map-get($foundation-palette, secondary)};
-  --fas-success-color: #{map-get($foundation-palette, success)};
-  --fas-warning-color: #{map-get($foundation-palette, warning)};
-  --fas-alert-color: #{map-get($foundation-palette, alert)};
+  --fas-secondary-color: #{map-get(app.$foundation-palette, secondary)};
+  --fas-success-color: #{map-get(app.$foundation-palette, success)};
+  --fas-warning-color: #{map-get(app.$foundation-palette, warning)};
+  --fas-alert-color: #{map-get(app.$foundation-palette, alert)};
 }
 
 // Foundation for Angular Sites component styles overrides

--- a/packages/ngx-foundation-sites/src/storybook/styles/_foundation-sites-settings.scss
+++ b/packages/ngx-foundation-sites/src/storybook/styles/_foundation-sites-settings.scss
@@ -1,3 +1,6 @@
+@import 'foundation-sites/scss/util/util';
+
+// GLOBAL
 $foundation-palette-default: (
   primary: #1779ba,
   secondary: #767676,
@@ -13,3 +16,4 @@ $foundation-palette-deep-purple-amber: (
   alert: #f44336 /* Material Red 500 */,
 );
 $foundation-palette: $foundation-palette-deep-purple-amber;
+@include add-foundation-colors;

--- a/packages/ngx-foundation-sites/src/storybook/styles/_foundation-sites-settings.scss
+++ b/packages/ngx-foundation-sites/src/storybook/styles/_foundation-sites-settings.scss
@@ -1,4 +1,4 @@
-@import 'foundation-sites/scss/util/util';
+@use 'foundation-sites/scss/foundation';
 
 // GLOBAL
 $foundation-palette-default: (
@@ -16,4 +16,5 @@ $foundation-palette-deep-purple-amber: (
   alert: #f44336 /* Material Red 500 */,
 );
 $foundation-palette: $foundation-palette-deep-purple-amber;
-@include add-foundation-colors;
+
+foundation.$foundation-palette: $foundation-palette;

--- a/packages/ngx-foundation-sites/src/storybook/styles/_foundation-sites.scss
+++ b/packages/ngx-foundation-sites/src/storybook/styles/_foundation-sites.scss
@@ -1,113 +1,20 @@
-/**
- * Foundation for Sites
- * Version 6.7.4
- * https://get.foundation
- * Licensed under MIT Open Source
- */
-
-// --- Dependencies ---
-@import 'foundation-sites/scss/vendor/normalize';
-@import 'foundation-sites/_vendor/sassy-lists/stylesheets/helpers/missing-dependencies';
-@import 'foundation-sites/_vendor/sassy-lists/stylesheets/helpers/true';
-@import 'foundation-sites/_vendor/sassy-lists/stylesheets/functions/contain';
-@import 'foundation-sites/_vendor/sassy-lists/stylesheets/functions/purge';
-@import 'foundation-sites/_vendor/sassy-lists/stylesheets/functions/remove';
-@import 'foundation-sites/_vendor/sassy-lists/stylesheets/functions/replace';
-@import 'foundation-sites/_vendor/sassy-lists/stylesheets/functions/to-list';
-
-// --- Settings ---
-// import your own `settings` here or
-// import and modify the default settings through
-// @import 'foundation-sites/scss/settings/settings';
 @import 'foundation-sites-settings';
-
-// --- Components ---
-// Utilities
-@import 'foundation-sites/scss/util/util';
-// Global styles
-@import 'foundation-sites/scss/global';
-@import 'foundation-sites/scss/forms/forms';
-@import 'foundation-sites/scss/typography/typography';
-
-// Grids
-@import 'foundation-sites/scss/grid/grid';
-@import 'foundation-sites/scss/xy-grid/xy-grid';
-// Generic components
-@import 'foundation-sites/scss/components/button';
-@import 'foundation-sites/scss/components/button-group';
-@import 'foundation-sites/scss/components/close-button';
-@import 'foundation-sites/scss/components/label';
-@import 'foundation-sites/scss/components/progress-bar';
-@import 'foundation-sites/scss/components/slider';
-@import 'foundation-sites/scss/components/switch';
-@import 'foundation-sites/scss/components/table';
-// Basic components
-@import 'foundation-sites/scss/components/badge';
-@import 'foundation-sites/scss/components/breadcrumbs';
-@import 'foundation-sites/scss/components/callout';
-@import 'foundation-sites/scss/components/card';
-@import 'foundation-sites/scss/components/dropdown';
-@import 'foundation-sites/scss/components/pagination';
-@import 'foundation-sites/scss/components/tooltip';
-
-// Containers
-@import 'foundation-sites/scss/components/accordion';
-@import 'foundation-sites/scss/components/media-object';
-@import 'foundation-sites/scss/components/orbit';
-@import 'foundation-sites/scss/components/responsive-embed';
-@import 'foundation-sites/scss/components/tabs';
-@import 'foundation-sites/scss/components/thumbnail';
-// Menu-based containers
-@import 'foundation-sites/scss/components/menu';
-@import 'foundation-sites/scss/components/menu-icon';
-@import 'foundation-sites/scss/components/accordion-menu';
-@import 'foundation-sites/scss/components/drilldown';
-@import 'foundation-sites/scss/components/dropdown-menu';
-
-// Layout components
-@import 'foundation-sites/scss/components/off-canvas';
-@import 'foundation-sites/scss/components/reveal';
-@import 'foundation-sites/scss/components/sticky';
-@import 'foundation-sites/scss/components/title-bar';
-@import 'foundation-sites/scss/components/top-bar';
-
-// Helpers
-@import 'foundation-sites/scss/components/float';
-@import 'foundation-sites/scss/components/flex';
-@import 'foundation-sites/scss/components/visibility';
-@import 'foundation-sites/scss/prototype/prototype';
+@import 'foundation-sites/scss/foundation';
+@import 'motion-ui/motion-ui';
 
 /**
  * 1. Use component styles instead of global styles.
  */
-@mixin foundation-example-app(
-  $flex: true,
-  $prototype: false,
-  $xy-grid: $xy-grid
-) {
-  @if $flex {
-    $global-flexbox: true !global;
-  }
-
-  @if $xy-grid {
-    $xy-grid: true !global;
-  }
-
+@mixin foundation-example-app() {
   // Global styles
   @include foundation-global-styles;
   @include foundation-forms;
   @include foundation-typography;
 
-  // Grids
-  @if not $flex {
-    @include foundation-grid;
-  } @else {
-    @if $xy-grid {
-      @include foundation-xy-grid-classes;
-    } @else {
-      @include foundation-flex-grid;
-    }
-  }
+  // Grids (choose one)
+  @include foundation-xy-grid-classes;
+  // @include foundation-grid;
+  @include foundation-flex-grid;
 
   // Generic components
   @include foundation-button;
@@ -116,6 +23,7 @@
   @include foundation-label;
   // @include foundation-progress-bar; /* [1] */
   @include foundation-slider;
+  @include foundation-range-input;
   @include foundation-switch;
   @include foundation-table;
   // Basic components
@@ -150,11 +58,11 @@
 
   // Helpers
   @include foundation-float-classes;
-  @if $flex {
-    @include foundation-flex-classes;
-  }
+  @include foundation-flex-classes;
   @include foundation-visibility-classes;
-  @if $prototype {
-    @include foundation-prototype-classes;
-  }
+  // @include foundation-prototype-classes;
+
+  // Motion UI
+  @include motion-ui-transitions;
+  @include motion-ui-animations;
 }

--- a/packages/ngx-foundation-sites/src/storybook/styles/_foundation-sites.scss
+++ b/packages/ngx-foundation-sites/src/storybook/styles/_foundation-sites.scss
@@ -1,68 +1,68 @@
-@import 'foundation-sites-settings';
-@import 'foundation-sites/scss/foundation';
-@import 'motion-ui/motion-ui';
+@forward 'foundation-sites-settings';
+@use 'foundation-sites/scss/foundation';
+@use 'motion-ui/motion-ui';
 
 /**
  * 1. Use component styles instead of global styles.
  */
 @mixin foundation-example-app() {
   // Global styles
-  @include foundation-global-styles;
-  @include foundation-forms;
-  @include foundation-typography;
+  @include foundation.foundation-global-styles;
+  @include foundation.foundation-forms;
+  @include foundation.foundation-typography;
 
   // Grids (choose one)
-  @include foundation-xy-grid-classes;
-  // @include foundation-grid;
-  @include foundation-flex-grid;
+  @include foundation.foundation-xy-grid-classes;
+  // @include foundation.foundation-grid;
+  @include foundation.foundation-flex-grid;
 
   // Generic components
-  @include foundation-button;
-  @include foundation-button-group;
-  @include foundation-close-button;
-  @include foundation-label;
-  // @include foundation-progress-bar; /* [1] */
-  @include foundation-slider;
-  @include foundation-range-input;
-  @include foundation-switch;
-  @include foundation-table;
+  @include foundation.foundation-button;
+  @include foundation.foundation-button-group;
+  @include foundation.foundation-close-button;
+  @include foundation.foundation-label;
+  // @include foundation.foundation-progress-bar; /* [1] */
+  @include foundation.foundation-slider;
+  @include foundation.foundation-range-input;
+  @include foundation.foundation-switch;
+  @include foundation.foundation-table;
   // Basic components
-  @include foundation-badge;
-  @include foundation-breadcrumbs;
-  @include foundation-callout;
-  // @include foundation-card; /* [1] */
-  @include foundation-dropdown;
-  @include foundation-pagination;
-  @include foundation-tooltip;
+  @include foundation.foundation-badge;
+  @include foundation.foundation-breadcrumbs;
+  @include foundation.foundation-callout;
+  // @include foundation.foundation-card; /* [1] */
+  @include foundation.foundation-dropdown;
+  @include foundation.foundation-pagination;
+  @include foundation.foundation-tooltip;
 
   // Containers
-  @include foundation-accordion;
-  @include foundation-media-object;
-  @include foundation-orbit;
-  @include foundation-responsive-embed;
-  // @include foundation-tabs; /* [1] */
-  @include foundation-thumbnail;
+  @include foundation.foundation-accordion;
+  @include foundation.foundation-media-object;
+  @include foundation.foundation-orbit;
+  @include foundation.foundation-responsive-embed;
+  // @include foundation.foundation-tabs; /* [1] */
+  @include foundation.foundation-thumbnail;
   // Menu-based containers
-  @include foundation-menu;
-  @include foundation-menu-icon;
-  @include foundation-accordion-menu;
-  @include foundation-drilldown-menu;
-  @include foundation-dropdown-menu;
+  @include foundation.foundation-menu;
+  @include foundation.foundation-menu-icon;
+  @include foundation.foundation-accordion-menu;
+  @include foundation.foundation-drilldown-menu;
+  @include foundation.foundation-dropdown-menu;
 
   // Layout components
-  @include foundation-off-canvas;
-  @include foundation-reveal;
-  @include foundation-sticky;
-  @include foundation-title-bar;
-  @include foundation-top-bar;
+  @include foundation.foundation-off-canvas;
+  @include foundation.foundation-reveal;
+  @include foundation.foundation-sticky;
+  @include foundation.foundation-title-bar;
+  @include foundation.foundation-top-bar;
 
   // Helpers
-  @include foundation-float-classes;
-  @include foundation-flex-classes;
-  @include foundation-visibility-classes;
-  // @include foundation-prototype-classes;
+  @include foundation.foundation-float-classes;
+  @include foundation.foundation-flex-classes;
+  @include foundation.foundation-visibility-classes;
+  // @include foundation.foundation-prototype-classes;
 
   // Motion UI
-  @include motion-ui-transitions;
-  @include motion-ui-animations;
+  @include motion-ui.motion-ui-transitions;
+  @include motion-ui.motion-ui-animations;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12410,6 +12410,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4, mkdirp@~1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+motion-ui@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/motion-ui/-/motion-ui-2.0.4.tgz#3d9423c26b76e577da19b5f0915fea067433bf1a"
+  integrity sha512-7GjtcXXqRHUQGH9Gm8KLbvx9sz5tNGlftsaJ/J5d4q33PzfgKnUm+OynDji4VR3fiZXPT3nMkzBQlZsifYTIOg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
Global example Foundation app styles used for Storybook have been migrated to Sass modules but global Foundation for Sites SCSS variables such as $global-flexbox prevent us from migrating component stylesheets to Sass modules.

Closes #57.