### PR TITLE
feat!: use inidividual style mixins

### DIFF
--- a/packages/ngx-foundation-sites/src/lib/_global-settings.scss
+++ b/packages/ngx-foundation-sites/src/lib/_global-settings.scss
@@ -1,5 +1,5 @@
 // Foundation for Angular Sites default global settings
-// Must be included with every component
+// Must be included with every top-level component
 :root {
   --fas-white: #fefefe;
   --fas-primary-color: #1779ba;

--- a/packages/ngx-foundation-sites/src/lib/_global-settings.scss
+++ b/packages/ngx-foundation-sites/src/lib/_global-settings.scss
@@ -1,9 +1,21 @@
+// Foundation for Sites tools
+@import 'foundation-sites/scss/util/util';
+
+$fas-white: #fefefe;
+$fas-primary-color: #1779ba;
+$fas-black: #0a0a0a;
+
 // Foundation for Angular Sites default global settings
 // Must be included with every top-level component
 :root {
-  --fas-white: #fefefe;
-  --fas-primary-color: #1779ba;
+  --fas-white: $fas-white;
+  --fas-primary-color: $fas-primary-color;
+  --fas-primary-color-contrast: color-pick-contrast(
+    $fas-primary-color,
+    ($fas-white, $fas-black)
+  );
   --fas-primary-color-dark: #1468a0;
+  --fas-primary-color-tinted: smart-scale($fas-primary-color);
   --fas-secondary-color: #767676;
   --fas-success-color: #3adb76;
   --fas-warning-color: #ffae00;

--- a/packages/ngx-foundation-sites/src/lib/card/_foundation-card-settings.scss
+++ b/packages/ngx-foundation-sites/src/lib/card/_foundation-card-settings.scss
@@ -1,0 +1,9 @@
+// Foundation for Sites Card settings
+$card-background: var(--fas-card-background);
+$card-font-color: var(--fas-card-font-color);
+$card-divider-background: var(--fas-card-divider-background);
+$card-border: var(--fas-card-border);
+$card-shadow: var(--fas-card-shadow);
+$card-border-radius: var(--fas-card-border-radius);
+$card-padding: var(--fas-card-padding);
+$card-margin-bottom: var(--fas-card-margin-bottom);

--- a/packages/ngx-foundation-sites/src/lib/card/card-divider.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/card/card-divider.component.scss
@@ -1,0 +1,18 @@
+@import '../global-foundation-sites-settings';
+
+// Foundation for Sites global tools
+
+// Foundation for Sites Card settings
+@import 'foundation-card-settings';
+
+// Foundation for Sites Card tools
+@import 'foundation-sites/scss/components/card';
+
+// Foundation for Sites Card tools overrides
+
+fas-card-divider {
+  // Foundation for Sites Card styles
+  @include card-divider;
+
+  // Foundation for Angular Sites Card styles
+}

--- a/packages/ngx-foundation-sites/src/lib/card/card-divider.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/card/card-divider.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  HostBinding,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -11,12 +10,8 @@ import {
   encapsulation: ViewEncapsulation.None,
   selector: 'fas-card-divider',
   exportAs: 'fasCardDivider',
+  styleUrls: ['./card-divider.component.scss'],
   imports: [],
   template: `<ng-content></ng-content>`,
 })
-export class FasCardDividerComponent {
-  @HostBinding('className')
-  protected get className(): string {
-    return 'card-divider';
-  }
-}
+export class FasCardDividerComponent {}

--- a/packages/ngx-foundation-sites/src/lib/card/card-section.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/card/card-section.component.scss
@@ -1,0 +1,19 @@
+@import '../global-foundation-sites-settings';
+
+// Foundation for Sites global tools
+
+// Foundation for Sites Card settings
+@import 'foundation-card-settings';
+
+// Foundation for Sites Card tools
+@import 'foundation-sites/scss/components/card';
+
+// Foundation for Sites Card tools overrides
+
+fas-card-section {
+  // Foundation for Sites Card styles
+  @include card-section;
+
+  // Foundation for Angular Sites Card styles
+  display: block;
+}

--- a/packages/ngx-foundation-sites/src/lib/card/card-section.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/card/card-section.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  HostBinding,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -11,19 +10,8 @@ import {
   encapsulation: ViewEncapsulation.None,
   selector: 'fas-card-section',
   exportAs: 'fasCardSection',
-  styles: [
-    `
-      fas-card-section {
-        display: block;
-      }
-    `,
-  ],
+  styleUrls: ['./card-section.component.scss'],
   imports: [],
   template: `<ng-content></ng-content>`,
 })
-export class FasCardSectionComponent {
-  @HostBinding('className')
-  protected get className(): string {
-    return 'card-section';
-  }
-}
+export class FasCardSectionComponent {}

--- a/packages/ngx-foundation-sites/src/lib/card/card.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/card/card.component.scss
@@ -3,14 +3,7 @@
 // Foundation for Sites global tools
 
 // Foundation for Sites Card settings
-$card-background: var(--fas-card-background);
-$card-font-color: var(--fas-card-font-color);
-$card-divider-background: var(--fas-card-divider-background);
-$card-border: var(--fas-card-border);
-$card-shadow: var(--fas-card-shadow);
-$card-border-radius: var(--fas-card-border-radius);
-$card-padding: var(--fas-card-padding);
-$card-margin-bottom: var(--fas-card-margin-bottom);
+@import 'foundation-card-settings';
 
 // Foundation for Sites Card tools
 @import 'foundation-sites/scss/components/card';
@@ -28,8 +21,8 @@ fas-card {
   --fas-card-padding: var(--fas-global-padding);
   --fas-card-margin-bottom: var(--fas-global-margin);
 
+  // Foundation for Sites Card styles
+  @include card-container;
+
   // Foundation for Angular Sites Card styles
 }
-
-// Foundation for Sites Card styles
-@include foundation-card;

--- a/packages/ngx-foundation-sites/src/lib/card/card.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/card/card.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  HostBinding,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -15,9 +14,4 @@ import {
   imports: [],
   template: ` <ng-content></ng-content> `,
 })
-export class FasCardComponent {
-  @HostBinding('className')
-  protected get className(): string {
-    return 'card';
-  }
-}
+export class FasCardComponent {}

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/meter/meter.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/meter/meter.component.scss
@@ -1,6 +1,7 @@
 @import '../../global-foundation-sites-settings';
 
 // Foundation for Sites global tools
+@import 'foundation-sites/scss/util/util';
 
 // Foundation for Sites Meter settings
 $meter-height: var(--fas-meter-height);
@@ -15,6 +16,7 @@ $meter-fill-bad: var(--fas-meter-fill-bad);
 
 // Foundation for Sites Meter tools overrides
 
+// Foundation for Angular Sites Meter tools
 @mixin _fas-meter-appearance($height) {
   //
   // 1. Fix appearance in Chrome/Safari/Edge.
@@ -27,6 +29,9 @@ $meter-fill-bad: var(--fas-meter-fill-bad);
     height: $meter-height; // [1]
   }
 }
+
+// Foundation for Sites Meter styles
+@include foundation-meter-element;
 
 [fas-meter] {
   // Foundation for Angular Sites Meter settings
@@ -43,6 +48,3 @@ $meter-fill-bad: var(--fas-meter-fill-bad);
   // Foundation for Angular Sites Meter styles
   display: block;
 }
-
-// Foundation for Sites Meter styles
-@include foundation-meter-element;

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/_foundation-progress-bar-settings.scss
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/_foundation-progress-bar-settings.scss
@@ -1,0 +1,6 @@
+// Foundation for Sites Progress Bar settings
+$progress-height: var(--fas-progress-height);
+$progress-background: var(--fas-progress-background);
+$progress-margin-bottom: var(--fas-progress-margin-bottom);
+$progress-meter-background: var(--fas-progress-meter-background);
+$progress-radius: var(--fas-progress-radius);

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-bar.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-bar.component.ts
@@ -34,10 +34,6 @@ export class FasProgressBarComponent {
     this.#presenter.updateColor(color);
   }
 
-  @HostBinding('class.progress')
-  protected get componentClassEnabled(): boolean {
-    return true;
-  }
   @HostBinding('role')
   protected get roleAttribute(): string {
     return 'progressbar';

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-meter-text.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-meter-text.component.scss
@@ -1,6 +1,7 @@
 @import '../../global-foundation-sites-settings';
 
 // Foundation for Sites global tools
+@import 'foundation-sites/scss/util/util';
 
 // Foundation for Sites Progress Bar settings
 @import 'foundation-progress-bar-settings';
@@ -10,17 +11,20 @@
 
 // Foundation for Sites Progress Bar tools overrides
 
-fas-progress-bar {
-  // Foundation for Angular Sites Progress Bar settings
-  --fas-progress-height: 1rem;
-  --fas-progress-background: var(--fas-medium-gray);
-  --fas-progress-margin-bottom: var(--fas-global-margin);
-  --fas-progress-meter-background: var(--fas-primary-color);
-  --fas-progress-radius: var(--fas-global-radius);
-
+fas-progress-meter-text {
   // Foundation for Sites Progress Bar styles
-  @include progress-container;
+  @include progress-meter-text;
 
   // Foundation for Angular Sites Progress Bar styles
-  display: block;
+  display: inline-block;
+}
+
+fas-progress-bar {
+  @each $name, $color in $foundation-palette {
+    &.#{$name} {
+      fas-progress-meter {
+        background-color: $color;
+      }
+    }
+  }
 }

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-meter-text.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-meter-text.component.ts
@@ -2,7 +2,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  HostBinding,
   inject,
   Input,
   ViewEncapsulation,
@@ -16,13 +15,7 @@ import { ProgressBarStore } from './progress-bar.store';
   encapsulation: ViewEncapsulation.None,
   selector: 'fas-progress-meter-text',
   exportAs: 'fasProgressMeterText',
-  styles: [
-    `
-      fas-progress-meter-text {
-        display: inline-block;
-      }
-    `,
-  ],
+  styleUrls: ['./progress-meter-text.component.scss'],
   imports: [],
   template: `<ng-content></ng-content>`,
 })
@@ -36,11 +29,6 @@ export class FasProgressMeterTextComponent {
   @Input()
   set accessibleText(accessibleText: string | null) {
     this.#progressBar.updateAccessibleText(accessibleText);
-  }
-
-  @HostBinding('class.progress-meter-text')
-  protected get componentClassEnabled(): boolean {
-    return true;
   }
 
   // Use protected lifecycle hooks to minimize the public API surface

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-meter.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-meter.component.scss
@@ -1,6 +1,7 @@
 @import '../../global-foundation-sites-settings';
 
 // Foundation for Sites global tools
+@import 'foundation-sites/scss/util/util';
 
 // Foundation for Sites Progress Bar settings
 @import 'foundation-progress-bar-settings';
@@ -10,17 +11,20 @@
 
 // Foundation for Sites Progress Bar tools overrides
 
-fas-progress-bar {
-  // Foundation for Angular Sites Progress Bar settings
-  --fas-progress-height: 1rem;
-  --fas-progress-background: var(--fas-medium-gray);
-  --fas-progress-margin-bottom: var(--fas-global-margin);
-  --fas-progress-meter-background: var(--fas-primary-color);
-  --fas-progress-radius: var(--fas-global-radius);
-
+fas-progress-meter {
   // Foundation for Sites Progress Bar styles
-  @include progress-container;
+  @include progress-meter;
 
   // Foundation for Angular Sites Progress Bar styles
   display: block;
+}
+
+fas-progress-bar {
+  @each $name, $color in $foundation-palette {
+    &.#{$name} {
+      fas-progress-meter {
+        background-color: $color;
+      }
+    }
+  }
 }

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-meter.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress-bar/progress-meter.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  HostBinding,
   inject,
   Input,
   ViewEncapsulation,
@@ -19,6 +18,7 @@ import {
   encapsulation: ViewEncapsulation.None,
   selector: 'fas-progress-meter',
   exportAs: 'fasProgressMeter',
+  styleUrls: ['./progress-meter.component.scss'],
   imports: [],
   template: `<ng-content select="fas-progress-meter-text"></ng-content>`,
   viewProviders: [provideProgressMeterPresenter()],
@@ -40,10 +40,5 @@ export class FasProgressMeterComponent {
   @Input()
   set value(value: number | null) {
     this.#progressBar.updateValue(value);
-  }
-
-  @HostBinding('class.progress-meter')
-  protected get componentClassEnabled(): true {
-    return true;
   }
 }

--- a/packages/ngx-foundation-sites/src/lib/progress-bar/progress/progress.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/progress-bar/progress/progress.component.scss
@@ -1,6 +1,7 @@
 @import '../../global-foundation-sites-settings';
 
 // Foundation for Sites global tools
+@import 'foundation-sites/scss/util/util';
 
 // Foundation for Sites Progress settings
 $progress-height: var(--fas-progress-height);
@@ -14,6 +15,9 @@ $progress-radius: var(--fas-progress-radius);
 
 // Foundation for Sites Progress tools overrides
 
+// Foundation for Sites Progress styles
+@include foundation-progress-element;
+
 [fas-progress] {
   // Foundation for Angular Sites Progress settings
   --fas-progress-height: 1rem;
@@ -23,8 +27,4 @@ $progress-radius: var(--fas-progress-radius);
   --fas-progress-radius: var(--fas-global-radius);
 
   // Foundation for Angular Sites Progress styles
-  display: block;
 }
-
-// Foundation for Sites Progress styles
-@include foundation-progress-element;

--- a/packages/ngx-foundation-sites/src/lib/tabs/_foundation-tabs-settings.scss
+++ b/packages/ngx-foundation-sites/src/lib/tabs/_foundation-tabs-settings.scss
@@ -1,0 +1,14 @@
+// Foundation for Sites Tabs settings
+$tab-margin: var(--fas-tab-margin);
+$tab-background: var(--fas-tab-background);
+$tab-color: var(--fas-tab-color);
+$tab-color-hover: var(--fas-tab-color-hover);
+$tab-background-active: var(--fas-tab-background-active);
+$tab-active-color: var(--fas-tab-active-color);
+$tab-item-font-size: var(--fas-tab-item-font-size);
+$tab-item-background-hover: var(--fas-tab-item-background-hover);
+$tab-item-padding: var(--fas-tab-item-padding);
+$tab-content-background: var(--fas-tab-content-background);
+$tab-content-border: var(--fas-tab-content-border);
+$tab-content-color: var(--fas-tab-content-color);
+$tab-content-padding: var(--fas-tab-content-padding);

--- a/packages/ngx-foundation-sites/src/lib/tabs/collapsing-tabs.stories.ts
+++ b/packages/ngx-foundation-sites/src/lib/tabs/collapsing-tabs.stories.ts
@@ -44,7 +44,7 @@ export const CollapsingTabs: Story = args => ({
       </fas-tab>
 
       <fas-tab id="panel3c" title="Collapsing tab 3">
-        <img class="thumbnail" src="/assets/img/generic/rectangle-3.jpg" />
+        <img class="thumbnail" src="https://get.foundation/sites/docs/assets/img/generic/rectangle-3.jpg" />
       </fas-tab>
 
       <fas-tab id="panel4c" title="Collapsing tab 4">

--- a/packages/ngx-foundation-sites/src/lib/tabs/tab.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/tabs/tab.component.scss
@@ -1,0 +1,18 @@
+@import '../global-foundation-sites-settings';
+
+// Foundation for Sites global tools
+
+// Foundation for Sites Tabs settings
+@import 'foundation-tabs-settings';
+
+// Foundation for Sites Tabs tools
+@import 'foundation-sites/scss/components/tabs';
+
+// Foundation for Sites Tabs tools overrides
+
+fas-tab {
+  // Foundation for Sites Tabs styles
+  @include tabs-panel;
+
+  // Foundation for Angular Sites Tabs styles
+}

--- a/packages/ngx-foundation-sites/src/lib/tabs/tab.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/tabs/tab.component.ts
@@ -18,6 +18,7 @@ let serialNumber = 1;
   encapsulation: ViewEncapsulation.None,
   selector: 'fas-tab',
   exportAs: 'fasTab',
+  styleUrls: ['./tab.component.scss'],
   imports: [],
   template: `<ng-content></ng-content>`,
 })
@@ -61,10 +62,6 @@ export class FasTabComponent {
   @HostBinding('attr.aria-labelledby')
   protected get ariaLabelledBy(): string {
     return `${this.id}-label`;
-  }
-  @HostBinding('className')
-  protected get className(): string {
-    return 'tabs-panel';
   }
   @HostBinding('id')
   get id(): string {

--- a/packages/ngx-foundation-sites/src/lib/tabs/tabs.component.scss
+++ b/packages/ngx-foundation-sites/src/lib/tabs/tabs.component.scss
@@ -1,22 +1,10 @@
 @import '../global-foundation-sites-settings';
 
 // Foundation for Sites global tools
-@import 'foundation-sites/scss/util/mixins';
+@import 'foundation-sites/scss/util/util';
 
 // Foundation for Sites Tabs settings
-$tab-margin: var(--fas-tab-margin);
-$tab-background: var(--fas-tab-background);
-$tab-color: var(--fas-tab-color);
-$tab-color-hover: var(--fas-tab-color-hover);
-$tab-background-active: var(--fas-tab-background-active);
-$tab-active-color: var(--fas-tab-active-color);
-$tab-item-font-size: var(--fas-tab-item-font-size);
-$tab-item-background-hover: var(--fas-tab-item-background-hover);
-$tab-item-padding: var(--fas-tab-item-padding);
-$tab-content-background: var(--fas-tab-content-background);
-$tab-content-border: var(--fas-tab-content-border);
-$tab-content-color: var(--fas-tab-content-color);
-$tab-content-padding: var(--fas-tab-content-padding);
+@import 'foundation-tabs-settings';
 
 // Foundation for Sites Tabs tools
 @import 'foundation-sites/scss/components/tabs';
@@ -30,7 +18,6 @@ $tab-content-padding: var(--fas-tab-content-padding);
   $padding: $tab-item-padding,
   $font-size: $tab-item-font-size,
   $color: $tab-color,
-  $color-hover: $tab-color-hover /* [1] */,
   $color-active: $tab-active-color,
   $background-hover: $tab-item-background-hover,
   $background-active: $tab-background-active
@@ -47,7 +34,7 @@ $tab-content-padding: var(--fas-tab-content-padding);
 
     &:hover {
       background: $background-hover;
-      color: $color-hover; // [1]
+      color: var(--fas-primary-color-dark); // [1]
     }
 
     &:focus,
@@ -63,7 +50,6 @@ fas-tabs {
   --fas-tab-margin: 0;
   --fas-tab-background: var(--fas-white);
   --fas-tab-color: var(--fas-primary-color);
-  --fas-tab-color-hover: var(--fas-primary-color-dark);
   --fas-tab-background-active: var(--fas-light-gray);
   --fas-tab-active-color: var(--fas-primary-color);
   --fas-tab-item-font-size: #{rem-calc(12)};
@@ -75,8 +61,57 @@ fas-tabs {
   --fas-tab-content-padding: 1rem;
 
   // Foundation for Sites Tabs styles
-  @include foundation-tabs;
 
   // Foundation for Angular Sites Tabs styles
   display: block;
+}
+
+.fas-tabs__tabs {
+  @include tabs-container;
+
+  // Vertical
+  &.vertical {
+    @include tabs-container-vertical;
+  }
+
+  // Simple
+  &.simple {
+    > li > a {
+      padding: 0;
+
+      &:hover {
+        background: transparent;
+      }
+    }
+  }
+
+  // Primary color
+  &.primary {
+    background: $primary-color;
+
+    > li > a {
+      color: var(--fas-primary-color-contrast);
+
+      &:hover,
+      &:focus {
+        background: var(--fas-primary-color-tinted);
+      }
+    }
+  }
+}
+
+.fas-tabs__tabs-title {
+  @include tabs-title;
+}
+
+.fas-tabs__tabs-content {
+  @include tabs-content;
+
+  &.vertical {
+    @include tabs-content-vertical;
+  }
+}
+
+.fas-tabs__tabs-panel {
+  @include tabs-panel;
 }

--- a/packages/ngx-foundation-sites/src/lib/tabs/tabs.component.ts
+++ b/packages/ngx-foundation-sites/src/lib/tabs/tabs.component.ts
@@ -30,10 +30,10 @@ import { FasTabComponent } from './tab.component';
   styleUrls: ['../_global-settings.scss', './tabs.component.scss'],
   imports: [NgFor, RouterLink],
   template: `
-    <ul class="tabs" [class.vertical]="vertical">
+    <ul class="fas-tabs__tabs" [class.vertical]="vertical">
       <li
         *ngFor="let tab of tabs"
-        class="tabs-title"
+        class="fas-tabs__tabs-title"
         [class.is-active]="tab.active"
         role="presentation"
       >
@@ -50,7 +50,7 @@ import { FasTabComponent } from './tab.component';
       </li>
     </ul>
 
-    <div class="tabs-content" [class.vertical]="vertical">
+    <div class="fas-tabs__tabs-content" [class.vertical]="vertical">
       <ng-content select="fas-tab"></ng-content>
     </div>
   `,

--- a/packages/ngx-foundation-sites/src/storybook/styles.scss
+++ b/packages/ngx-foundation-sites/src/storybook/styles.scss
@@ -1,3 +1,5 @@
+@use 'foundation-sites/scss/global';
+@use 'foundation-sites/scss/util/util';
 @use 'styles/foundation-sites' as app;
 
 @include app.foundation-example-app;
@@ -5,6 +7,11 @@
 // Foundation for Angular Sites global styles overrides
 :root:root /* Increase specificity to override component styles */ {
   --fas-primary-color: #{map-get(app.$foundation-palette, primary)};
+  --fas-primary-color-contrast: #{util.color-pick-contrast(
+      map-get(app.$foundation-palette, primary),
+      (global.$white, global.$black),
+      global.$global-color-pick-contrast-tolerance // 0
+    )};
   --fas-primary-color-dark: #{scale-color(
       map-get(app.$foundation-palette, primary),
       $lightness: -14%
@@ -18,6 +25,6 @@
 // Foundation for Angular Sites component styles overrides
 :root /* Increase specificity to override component styles */ {
   fas-tabs {
-    --fas-tab-item-font-size: #{rem-calc(14px)};
+    --fas-tab-item-font-size: #{util.rem-calc(14)};
   }
 }

--- a/packages/ngx-foundation-sites/testing/src/lib/tabs/tab-panel.harness.ts
+++ b/packages/ngx-foundation-sites/testing/src/lib/tabs/tab-panel.harness.ts
@@ -1,11 +1,15 @@
-import { ComponentHarness, HarnessPredicate, TestElement } from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  HarnessPredicate,
+  TestElement,
+} from '@angular/cdk/testing';
 
 import { coerceBooleanProperty } from '../util-coercion/coerce-boolean-property';
 import { FasTabPanelHarnessFilters } from './tab-panel-harness-filters';
 import { FasTabHarness } from './tab.harness';
 
 export class FasTabPanelHarness extends ComponentHarness {
-  static hostSelector = '.tabs-panel';
+  static hostSelector = 'fas-tab';
 
   static with(
     options: FasTabPanelHarnessFilters

--- a/packages/ngx-foundation-sites/testing/src/lib/tabs/tab.harness.ts
+++ b/packages/ngx-foundation-sites/testing/src/lib/tabs/tab.harness.ts
@@ -4,7 +4,7 @@ import { coerceBooleanProperty } from '../util-coercion/coerce-boolean-property'
 import { FasTabHarnessFilters } from './tab-harness-filters';
 
 export class FasTabHarness extends ComponentHarness {
-  static hostSelector = '.tabs-title';
+  static hostSelector = '.fas-tabs__tabs-title';
 
   #getLabel: AsyncFactoryFn<TestElement> = this.locatorFor('a');
 

--- a/packages/ngx-foundation-sites/testing/src/lib/tabs/tabs.harness.ts
+++ b/packages/ngx-foundation-sites/testing/src/lib/tabs/tabs.harness.ts
@@ -1,4 +1,9 @@
-import { AsyncFactoryFn, ComponentHarness, HarnessPredicate, TestElement } from '@angular/cdk/testing';
+import {
+  AsyncFactoryFn,
+  ComponentHarness,
+  HarnessPredicate,
+  TestElement,
+} from '@angular/cdk/testing';
 
 import { FasTabHarnessFilters } from './tab-harness-filters';
 import { FasTabPanelHarnessFilters } from './tab-panel-harness-filters';
@@ -9,7 +14,7 @@ import { FasTabsHarnessFilters } from './tabs-harness-filters';
 export class FasTabsHarness extends ComponentHarness {
   static hostSelector = 'fas-tabs';
 
-  #getTabs: AsyncFactoryFn<TestElement> = this.locatorFor('.tabs');
+  #getTabs: AsyncFactoryFn<TestElement> = this.locatorFor('.fas-tabs__tabs');
 
   static with(
     options: FasTabsHarnessFilters


### PR DESCRIPTION
# Features
- Remove `--fas-tab-color-hover` CSS custom property in favor of `--fas-primary-color-dark`

# Bug fixes
- Add `--fas-primary-color-contrast` CSS custom property to support `color-pick-contrast($primary-color)` used for Tabs styles
- Add `--fas-primary-color-tinted` CSS custom property to support `smart-scale($primary-color)` used for Tabs styles

# Performance optimizations
- Use individual style mixins for child components instead of all-in-one mixins for top-level components
- Use selectors with lower specificity where possible

# Refactors
- Use BEM-style CSS classes where element names cannot be used

# Documentation
- Fix `rem-calc`-calculated CSS custom property values
- Fix thumbnail URL in *Collapsing tabs* story
- Use Sass modules for example foundation app

Closes #90.

BREAKING CHANGES
Remove `--fas-tab-color-hover` CSS custom property in favor of `--fas-primary-color-dark` which was previously the default value.